### PR TITLE
Add sequence ID to emit calls to prevent race

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -42,11 +42,11 @@ module.exports = exports = function(options) {
     emit: function(after) {
       function checkComplete() {
         if (isComplete()) {
-          var associatedRequest = requestId;
+          var associatedRequestId = requestId;
           setImmediate(function() {
             // Avoid a race condtion where pooled requests may come in while we still have
             // pending emit calls. This will generally only happen for very chatty emit callers.
-            if (requestId === associatedRequest) {
+            if (requestId === associatedRequestId) {
               emit();
             }
           });


### PR DESCRIPTION
If a page calls emit multiple times it's possible that the pool output may be
preemptively emitted on subsequent requests if they occur within a short
enough period. Adding a unique sequence identified to NOP any subsequent
operations.
