### PR TITLE
Create a separate fn scope for each $ instance

### DIFF
--- a/lib/jquery/index.js
+++ b/lib/jquery/index.js
@@ -12,8 +12,14 @@ module.exports = exports = function jQuery(window, html, exec, options) {
   html = undefined;
 
   function query(selector, context) {
+    /* jshint -W103 */
     var ret = root(selector, context);
     ret._$ = $;
+
+    // We need to remap ourselves to the private context and unfortunately
+    // the return behavior of the Cheerio constructo makes this difficult to
+    // implement without ramapping after the fact.
+    ret.__proto__ = $.fn;
     return ret;
   }
 
@@ -56,6 +62,8 @@ module.exports = exports = function jQuery(window, html, exec, options) {
       return query(selector, context);
     }
   }
+
+  $.fn = new Cheerio();
 
   $.each = function(elements, callback) {
     _.every(elements, function(el, i) {
@@ -116,8 +124,6 @@ module.exports = exports = function jQuery(window, html, exec, options) {
   };
 
   detect($, window);
-
-  $.fn = Cheerio.prototype;
 
   window.jQuery = window.Zepto = window.$ = $;
 

--- a/test/jquery/index.js
+++ b/test/jquery/index.js
@@ -99,6 +99,26 @@ describe('$', function() {
     });
   });
 
+  describe('$.fn', function() {
+    it('should allow augmentation', function() {
+      inst = $(window, '<div></div>');
+      inst.$.fn.foo = function() {
+        return 'success';
+      };
+      inst.$('div').foo().should.equal('success');
+      should.not.exist(inst.$('div').bar);
+
+      inst.$.fn.bar = function() {
+        return 'success';
+      };
+      inst.$('div').bar().should.equal('success');
+
+      inst = $(window, '<div></div>');
+      should.not.exist(inst.$('div').foo);
+      should.not.exist(inst.$('div').bar);
+    });
+  });
+
   describe('#each', function() {
     it('should iterate arrays', function() {
       var spy = this.spy(function(i, value) {


### PR DESCRIPTION
Defines a per-page $.fn instance that can be modified safely by pages without
causing their content to be retained or unexpected cross context $ operations.
