### PR TITLE
Allow for pool queue limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ Creates a pool of page objects.
 Shares the same options as the `page` method with a few distinctions:
 - `path` and `callback` will be ignored. The values passed to `navigate` will be used instead.
 - Adds the `poolSize` option used to specify the number of pages to create at once.
+- Adds the `maxQueue` option used to limit the number of requests that can be queued at a given time. If set a `EQUEUEFULL` error will be returned if this limit is exceeded.
+- Add the `queueTimeout` option used to timeout requests that pending in the queue. If triggered this will return a `EQUEUETIMEOUT` error.
 - Adds `navigated(page, existingPage)` callback which is called after a page is reused. This should be used to notify the application that the path has changed, i.e. `Backbone.history.loadUrl()` or similar. Will be called for all `pool.navigated` calls. `existingPage` will be true when the page has been used in a previous render cycle.
 - When `cacheResources` is falsy a `fs.watch` will be performed on all script files loaded into the pool. Should one change then the pool will be restarted. This will preempt any running requests, leaving them in an indeterminate state. In production it's recommended that this flag be set to `true`.
 

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -58,8 +58,9 @@ function getPage(pool, context, path, metadata, callback) {
       if (cache.queue.length) {
         // If there are pending calls then we continue them.
         var queued = cache.queue.shift();
+        clearTimeout(queued.timeout);
         setImmediate(function() {
-          getPage.apply(this, queued);
+          getPage.apply(this, queued.args);
         });
       }
 
@@ -87,7 +88,9 @@ function getPage(pool, context, path, metadata, callback) {
     }
   }
 
-  var page;
+  var page,
+      queueTimeout;
+
   if (cache.free.length) {
     // Execute the instance from an existing 
     page = cache.free.pop();
@@ -111,9 +114,36 @@ function getPage(pool, context, path, metadata, callback) {
     page = createPage(pool, options, watching);
     cache.pages.push(page);
   } else {
+    // Allow callers to limit the size of the queue and offer alternative rendering
+    // paths if it's unlikely that the request will be served in a timely manner.
+    if (options.maxQueue && (cache.queue.length >= options.maxQueue)) {
+      setImmediate(function() {
+        var err = new Error('EQUEUEFULL');
+        err.code = 'EQUEUEFULL';
+        callback(err);
+      });
+      return;
+    }
+
     // We hit our pool limit. Defer execution until we have
     // a VM entry available.
-    cache.queue.push(_.toArray(arguments));
+    var queueInfo = {
+      args: _.toArray(arguments)
+    };
+    cache.queue.push(queueInfo);
+
+    // Allow callers to limit the total time that is spent waiting in the queue and
+    // preempt for failover handling.
+    if (options.queueTimeout) {
+      queueInfo.timeout = setTimeout(function() {
+        cache.queue.splice(cache.queue.indexOf(queueInfo), 1);
+
+        var err = new Error('EQUEUETIMEOUT');
+        err.code = 'EQUEUETIMEOUT';
+        callback(err);
+      }, options.queueTimeout);
+    }
+
   }
 
   return page;


### PR DESCRIPTION
Adds `queueTimeout` and `maxQueue` pool options which can be used to help
prevent runaway queues and allow active failover when a pool has entered
queuing and partial starvation.

The general intent here is to allow for requests to preemptively serve client
side rendering responses when the server side path is under stress.
